### PR TITLE
feat: specify the location of the derivation with `derivation-path`

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -71,7 +71,7 @@ jobs:
         uses: ./
         with:
           verbose: true
-          derivation_path: ./tests/integration_tests/shell.nix
+          derivation-path: ./tests/integration_tests/shell.nix
           options: |
             --argstr customVarStr "Hello, World!"
           run: |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -47,6 +47,7 @@ jobs:
         uses: ./
         with:
           verbose: true
+          derivation-path: ./tests/integration_tests
           working-directory: ./tests/integration_tests
           options: |
             --arg customVarBool true

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -43,7 +43,7 @@ jobs:
       - uses: ./.github/actions/set_up_runner
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-      - name: Execute simple
+      - name: Execute in directory with shell.nix
         uses: ./
         with:
           verbose: true
@@ -55,13 +55,32 @@ jobs:
             echo "FIRST" > integration_test.out
             echo "${CUSTOM_VAR_BOOL}" >> integration_test.out
             echo "${CUSTOM_VAR_STR}" >> integration_test.out
-      - name: Confirm output
+      - name: Confirm output for Execute in directory with shell.nix
         shell: bash
         run: |
           output="$(<./tests/integration_tests/integration_test.out)"
           expected="$(cat <<-EOF
           FIRST
           true
+          Hello, World!
+          EOF
+          )"
+          [[ "${output}" == "${expected}" ]] || \
+            (echo >&2 "Ouptput from integration test does not match:" "${output}"; exit 1)
+      - name: Execute in directory without shell.nix
+        uses: ./
+        with:
+          verbose: true
+          derivation_path: ./tests/integration_tests/shell.nix
+          options: |
+            --argstr customVarStr "Hello, World!"
+          run: |
+            echo "${CUSTOM_VAR_STR}" >> integration_test2.out
+      - name: Confirm output for Execute in directory without shell.nix
+        shell: bash
+        run: |
+          output="$(<./integration_test2.out)"
+          expected="$(cat <<-EOF
           Hello, World!
           EOF
           )"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -47,6 +47,7 @@ jobs:
         uses: ./
         with:
           verbose: true
+          # Demonstrate passing a directory that contains a shell.nix.
           derivation-path: ./tests/integration_tests
           working-directory: ./tests/integration_tests
           options: |
@@ -72,6 +73,7 @@ jobs:
         uses: ./
         with:
           verbose: true
+          # Demonstrate passing a path to a shell.nix.
           derivation-path: ./tests/integration_tests/shell.nix
           options: |
             --argstr customVarStr "Hello, World!"

--- a/action.yaml
+++ b/action.yaml
@@ -16,6 +16,9 @@ inputs:
     type: string
     description: The path where the nix-shell execution should take place.
     default: .
+  derivation-path:
+    type: string
+    description: The path to the shell.nix or default.nix to use to set up the environment.
   verbose:
     type: boolean
     description: Enable debug output written to stderr.
@@ -30,5 +33,6 @@ runs:
         RNS_OPTS: ${{ inputs.options }}
         RNS_RUN: ${{ inputs.run }}
         RNS_PURE: ${{ inputs.pure }}
+        RNS_DERIVATION_PATH: ${{ inputs.derivation-path }}
         RNS_VERBOSE: ${{ inputs.verbose }}
       run: ${GITHUB_ACTION_PATH}/tools/run_nix_shell.sh

--- a/action.yaml
+++ b/action.yaml
@@ -14,11 +14,14 @@ inputs:
     description: Any parameters that are to be passed to nix-shell are specified here.
   working-directory:
     type: string
-    description: The path where the nix-shell execution should take place.
+    description: |
+      The path where the script will be executed. This is not the path where nix-shell is executed.
     default: .
   derivation-path:
     type: string
-    description: The path to the shell.nix or default.nix to use to set up the environment.
+    description: |
+      The path to directory or the shell.nix or default.nix to use to set up the environment. This
+      is the directory where nix-shell is executed.
   verbose:
     type: boolean
     description: Enable debug output written to stderr.

--- a/tests/tools_tests/BUILD.bazel
+++ b/tests/tools_tests/BUILD.bazel
@@ -4,6 +4,8 @@ run_nix_shell_test(name = "custom_var_bool_test")
 
 run_nix_shell_test(name = "custom_var_str_test")
 
+run_nix_shell_test(name = "derivation_path_test")
+
 run_nix_shell_test(name = "multi_line_script_test")
 
 run_nix_shell_test(name = "pure_test")

--- a/tests/tools_tests/derivation_path_test.sh
+++ b/tests/tools_tests/derivation_path_test.sh
@@ -1,0 +1,10 @@
+assert_msg="custom derivation path via RNS_DERIVATION_PATH"
+derivation_path="${PWD}/shell.nix"
+another_dir="${PWD}/somewhere_else"
+mkdir -p "${another_dir}"
+cd "${another_dir}"
+output="$( 
+RNS_DERIVATION_PATH="${derivation_path}" \
+  "${run_nix_shell_sh}" 'echo "${CUSTOM_VAR_STR}"' 
+)"
+assert_match "default" "${output}" "${assert_msg}"

--- a/tests/tools_tests/derivation_path_test.sh
+++ b/tests/tools_tests/derivation_path_test.sh
@@ -2,9 +2,9 @@ assert_msg="custom derivation path via RNS_DERIVATION_PATH"
 derivation_path="${PWD}/shell.nix"
 another_dir="${PWD}/somewhere_else"
 mkdir -p "${another_dir}"
-cd "${another_dir}"
 output="$( 
 RNS_DERIVATION_PATH="${derivation_path}" \
+  RNS_CWD="${another_dir}" \
   "${run_nix_shell_sh}" 'echo "${CUSTOM_VAR_STR}"' 
 )"
 assert_match "default" "${output}" "${assert_msg}"

--- a/tools/run_nix_shell.sh
+++ b/tools/run_nix_shell.sh
@@ -162,6 +162,7 @@ cmd+=( --run "${script}" )
 if is_verbose; then
   verbose_output="$(cat <<-EOF
 === run_nix_shell command-line invocation ===
+pwd: ${PWD}
 $( printf "%q " "${cmd[@]}" )
 ===
 EOF

--- a/tools/run_nix_shell.sh
+++ b/tools/run_nix_shell.sh
@@ -163,6 +163,8 @@ if is_verbose; then
   verbose_output="$(cat <<-EOF
 === run_nix_shell command-line invocation ===
 pwd: ${PWD}
+ls:
+$( ls -l )
 $( printf "%q " "${cmd[@]}" )
 ===
 EOF

--- a/tools/run_nix_shell.sh
+++ b/tools/run_nix_shell.sh
@@ -163,8 +163,6 @@ if is_verbose; then
   verbose_output="$(cat <<-EOF
 === run_nix_shell command-line invocation ===
 pwd: ${PWD}
-ls:
-$( ls -l )
 $( printf "%q " "${cmd[@]}" )
 ===
 EOF

--- a/tools/run_nix_shell.sh
+++ b/tools/run_nix_shell.sh
@@ -14,6 +14,15 @@ fail() {
   exit 1
 }
 
+absolute_path() {
+  local path="${1}"
+  local bname
+  local dname
+  bname="$( basename "${path}" )"
+  dname="$( dirname "${path}" )"
+  echo "$( cd "${dname}"; pwd )/${bname}"
+}
+
 # MARK - Arguments
 
 cwd="${RNS_CWD:-}"
@@ -87,6 +96,7 @@ fi
 # MARK - Process Options and Arguments
 
 if [[ -n "${derivation_path:-}" ]]; then
+  derivation_path="$( absolute_path "${derivation_path}" )"
   nix_shell_opts+=( "${derivation_path}" )
 fi
 

--- a/tools/run_nix_shell.sh
+++ b/tools/run_nix_shell.sh
@@ -18,6 +18,7 @@ fail() {
 
 cwd="${RNS_CWD:-}"
 script="${RNS_RUN:-}"
+derivation_path="${RNS_DERIVATION_PATH:-}"
 
 pure="${RNS_PURE:-true}"
 verbose="${RNS_VERBOSE:-false}"
@@ -70,11 +71,13 @@ if is_verbose; then
 RNS_CWD: ${RNS_CWD:-}
 RNS_OPTS: ${RNS_OPTS:-}
 RNS_RUN: ${RNS_RUN:-}
+RNS_DERIVATION_PATH: ${RNS_DERIVATION_PATH:-}
 RNS_PURE: ${RNS_PURE:-}
 cwd: ${cwd:-}
 nix_shell_opts: $( printf "%q " "${nix_shell_opts[@]}" )
 pure: ${pure:-}
 script: ${script:-}
+derivation_path: ${derivation_path:-}
 ===
 EOF
 )"
@@ -82,6 +85,10 @@ EOF
 fi
 
 # MARK - Process Options and Arguments
+
+if [[ -n "${derivation_path:-}" ]]; then
+  nix_shell_opts+=( "${derivation_path}" )
+fi
 
 if [[ "${pure}" == "true" ]]; then
   nix_shell_opts+=( --pure )


### PR DESCRIPTION
- Add `derivation-path` input to specify the location of the `shell.nix` or `default.nix`.
- Add unit tests and integration tests for this functionality.

Related to #4.